### PR TITLE
feat: 設定リセット機能を追加

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,7 @@ function setupEventListeners() {
     document.getElementById('addGarbage').addEventListener('click', addGarbageItem);
     document.getElementById('saveSettings').addEventListener('click', saveSettings);
     document.getElementById('enableNotification').addEventListener('click', requestNotificationPermission);
+    document.getElementById('resetSettings').addEventListener('click', resetAllSettings);
 
     document.addEventListener('click', function(e) {
         if (e.target.classList.contains('add-schedule')) {
@@ -451,5 +452,59 @@ function showNotification(garbageNames) {
             badge: 'icon-192.png',
             vibrate: [200, 100, 200]
         });
+    }
+}
+
+function resetAllSettings() {
+    if (confirm('すべての設定をリセットしますか？\nこの操作は取り消せません。')) {
+        localStorage.removeItem('garbageSettings');
+
+        const garbageSettings = document.getElementById('garbageSettings');
+        garbageSettings.innerHTML = `
+            <div class="garbage-item" data-garbage-id="0">
+                <h3>ゴミ設定</h3>
+                <input type="text" class="garbage-name" placeholder="ゴミ名（例：燃えるゴミ）" value="">
+
+                <div class="schedule-settings" data-garbage-id="0">
+                    <div class="schedule-item" data-schedule-id="0">
+                        <select class="frequency-type">
+                            <option value="every">毎週</option>
+                            <option value="nth">第n</option>
+                        </select>
+
+                        <select class="nth-week" style="display:none;">
+                            <option value="1">第1</option>
+                            <option value="2">第2</option>
+                            <option value="3">第3</option>
+                            <option value="4">第4</option>
+                            <option value="5">第5</option>
+                        </select>
+
+                        <select class="day-of-week">
+                            <option value="0">日曜日</option>
+                            <option value="1">月曜日</option>
+                            <option value="2">火曜日</option>
+                            <option value="3">水曜日</option>
+                            <option value="4">木曜日</option>
+                            <option value="5">金曜日</option>
+                            <option value="6">土曜日</option>
+                        </select>
+
+                        <button class="remove-schedule" style="display:none;">✕</button>
+                    </div>
+                </div>
+
+                <button class="add-schedule" data-garbage-id="0">+ 曜日を追加</button>
+                <button class="remove-garbage" style="display:none;">ゴミ設定を削除</button>
+            </div>
+        `;
+
+        document.getElementById('notificationTime').value = '07:30';
+        document.getElementById('nextGarbageDay').textContent = '';
+
+        garbageCounter = 1;
+        scheduleCounters = {};
+
+        alert('設定をリセットしました');
     }
 }

--- a/index.html
+++ b/index.html
@@ -65,6 +65,10 @@
         </div>
 
         <button id="saveSettings" class="save-settings">設定を保存</button>
+
+        <div class="reset-section">
+            <button id="resetSettings" class="reset-settings">すべての設定をリセット</button>
+        </div>
     </div>
 
     <script src="app.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -185,6 +185,25 @@ button {
     opacity: 0.9;
 }
 
+.reset-section {
+    margin-top: 20px;
+    padding-top: 20px;
+    border-top: 2px dashed #e0e0e0;
+}
+
+.reset-settings {
+    background: #e53e3e;
+    color: white;
+    width: 100%;
+    padding: 15px;
+    font-size: 16px;
+    font-weight: bold;
+}
+
+.reset-settings:hover {
+    background: #c53030;
+}
+
 @media (max-width: 600px) {
     .container {
         padding: 20px 15px;


### PR DESCRIPTION
## 概要
すべての設定を初期状態に戻すリセット機能を追加しました。

## 変更内容
- 「すべての設定をリセット」ボタンを追加
- 確認ダイアログで誤操作を防止
- ローカルストレージから設定を削除し、UIを初期状態に戻す
- リセットボタンは赤色の警告的なデザインで実装

## スクリーンショット
設定画面の下部に、破線で区切られたリセットセクションが追加されます。

## テストケース
- [ ] リセットボタンをクリックすると確認ダイアログが表示される
- [ ] キャンセルを選択すると何も変更されない
- [ ] OKを選択するとすべての設定がクリアされる
- [ ] リセット後、ゴミ設定が1つの初期状態に戻る
- [ ] 通知時間が07:30にリセットされる
- [ ] 次のゴミの日表示がクリアされる

🤖 Generated with [Claude Code](https://claude.ai/code)