### PR TITLE
fix: ボタン文言の曖昧さを解消

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
             </div>
         </div>
 
-        <button id="addGarbage" class="add-garbage">+ ゴミ設定を追加</button>
+        <button id="addGarbage" class="add-garbage">+ ゴミの日設定を追加</button>
 
         <div class="notification-settings">
             <h3>通知設定</h3>


### PR DESCRIPTION
## 変更内容
「+ ゴミ設定を追加」→「+ ゴミの日設定を追加」に変更

## 理由
- 「ゴミ設定」だと「ゴミのような設定」「不要な設定」と誤解される可能性がある
- 「ゴミの日設定」にすることで、明確に「ゴミの日の設定」であることを示す
- 日本語の面白い曖昧さを解消 😹

## 変更箇所
- index.html: ボタンのテキストのみ変更

小さいけど大切なUX改善です！